### PR TITLE
feat(subscription_items): Replace plans with price

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -1159,6 +1159,7 @@ module StripeMock
           statement_descriptor: nil,
           trial_period_days: nil
         },
+        price: 'PER_USER_PRICE1',
         quantity: 2
       }.merge(params)
     end

--- a/lib/stripe_mock/request_handlers/subscription_items.rb
+++ b/lib/stripe_mock/request_handlers/subscription_items.rb
@@ -20,16 +20,18 @@ module StripeMock
         params[:id] ||= new_id('si')
 
         require_param(:subscription) unless params[:subscription]
-        require_param(:plan) unless params[:plan]
+        require_param(:price) unless params[:price]
 
-        subscriptions_items[params[:id]] = Data.mock_subscription_item(params.merge(plan: plans[params[:plan]]))
+        subscriptions_items[params[:id]] = Data.mock_subscription_item(
+          params.merge(price: prices[params[:price]])
+        )
       end
 
       def update_subscription_item(route, method_url, params, headers)
         route =~ method_url
 
         subscription_item = assert_existence :subscription_item, $1, subscriptions_items[$1]
-        subscription_item.merge!(params.merge(plan: plans[params[:plan]]))
+        subscription_item.merge!(params.merge(price: prices[params[:price]]))
       end
     end
   end

--- a/spec/shared_stripe_examples/subscription_items_examples.rb
+++ b/spec/shared_stripe_examples/subscription_items_examples.rb
@@ -3,42 +3,42 @@ require 'spec_helper'
 shared_examples 'Subscription Items API' do
   let(:stripe_helper) { StripeMock.create_test_helper }
   let(:product) { stripe_helper.create_product(name: 'Silver Product') }
-  let(:plan) { stripe_helper.create_plan(product: product.id, id: 'silver_plan') }
-  let(:plan2) { stripe_helper.create_plan(amount: 100, id: 'one_more_1_plan', product: product.id) }
+  let(:price) { stripe_helper.create_price(product: product.id, id: 'silver_price') }
+  let(:price2) { stripe_helper.create_price(amount: 100, id: 'one_more_1_price', product: product.id) }
   let(:customer) { Stripe::Customer.create(source: stripe_helper.generate_card_token) }
-  let(:subscription) { Stripe::Subscription.create(customer: customer.id, items: [{ plan: plan.id }]) }
+  let(:subscription) { Stripe::Subscription.create(customer: customer.id, items: [{ price: price.id }]) }
 
   context 'creates an item' do
     it 'when required params only' do
-      item = Stripe::SubscriptionItem.create(plan: plan.id, subscription: subscription.id)
+      item = Stripe::SubscriptionItem.create(price: price.id, subscription: subscription.id)
 
       expect(item.id).to match(/^test_si/)
-      expect(item.plan.id).to eq(plan.id)
+      expect(item.price.id).to eq(price.id)
       expect(item.subscription).to eq(subscription.id)
     end
     it 'when no subscription params' do
-      expect { Stripe::SubscriptionItem.create(plan: plan.id) }.to raise_error { |e|
+      expect { Stripe::SubscriptionItem.create(price: price.id) }.to raise_error { |e|
         expect(e).to be_a(Stripe::InvalidRequestError)
         expect(e.param).to eq('subscription')
         expect(e.message).to eq('Missing required param: subscription.')
       }
     end
-    it 'when no plan params' do
+    it 'when no price params' do
       expect { Stripe::SubscriptionItem.create(subscription: subscription.id) }.to raise_error { |e|
         expect(e).to be_a(Stripe::InvalidRequestError)
-        expect(e.param).to eq('plan')
-        expect(e.message).to eq('Missing required param: plan.')
+        expect(e.param).to eq('price')
+        expect(e.message).to eq('Missing required param: price.')
       }
     end
   end
 
   context 'updates an item' do
-    let(:item) { Stripe::SubscriptionItem.create(plan: plan.id, subscription: subscription.id, quantity: 2 ) }
+    let(:item) { Stripe::SubscriptionItem.create(price: price.id, subscription: subscription.id, quantity: 2 ) }
 
-    it 'updates plan' do
-      updated_item = Stripe::SubscriptionItem.update(item.id, plan: plan2.id)
+    it 'updates price' do
+      updated_item = Stripe::SubscriptionItem.update(item.id, price: price2.id)
 
-      expect(updated_item.plan.id).to eq(plan2.id)
+      expect(updated_item.price.id).to eq(price2.id)
     end
     it 'updates quantity' do
       updated_item = Stripe::SubscriptionItem.update(item.id, quantity: 23)
@@ -56,8 +56,8 @@ shared_examples 'Subscription Items API' do
 
   context 'retrieves a list of items' do
     before do
-      Stripe::SubscriptionItem.create(plan: plan.id, subscription: subscription.id, quantity: 2 )
-      Stripe::SubscriptionItem.create(plan: plan2.id, subscription: subscription.id, quantity: 20)
+      Stripe::SubscriptionItem.create(price: price.id, subscription: subscription.id, quantity: 2 )
+      Stripe::SubscriptionItem.create(price: price2.id, subscription: subscription.id, quantity: 20)
     end
 
     it 'retrieves all subscription items' do


### PR DESCRIPTION
Initial fork PR. In here we can modify code we require to match latest Stripe API. We need to provide a price param to manage subscription items. 

The current status of gem has the previous plan implementation. This is blocking us from testing billing addons implementation.

References:
Prices management initially added in main repo here: https://github.com/stripe-ruby-mock/stripe-ruby-mock/compare/2.5.1...v3.1.0



