### PR TITLE
Add Account deleted fixture

### DIFF
--- a/lib/stripe_mock/api/webhooks.rb
+++ b/lib/stripe_mock/api/webhooks.rb
@@ -38,6 +38,7 @@ module StripeMock
     def self.event_list
       @__list = [
         'account.updated',
+        'account.deleted',
         'account.application.deauthorized',
         'account.external_account.created',
         'account.external_account.updated',

--- a/lib/stripe_mock/webhook_fixtures/account.deleted.json
+++ b/lib/stripe_mock/webhook_fixtures/account.deleted.json
@@ -1,0 +1,6 @@
+{
+  "id": "acct_1FcNnrKVaJ4hjayX",
+  "object": "account",
+  "deleted": true
+}
+


### PR DESCRIPTION
This PR adds a fixture for the account deleted event, as we currently do not support it

![CleanShot 2022-11-11 at 15 18 52](https://user-images.githubusercontent.com/20502556/201359023-140ecaa0-f377-40bd-909b-4046a593209a.png)

Response taken from [here](https://stripe.com/docs/api/accounts/delete)

c.c @dduqueti 
