### PR TITLE
[fix] Allow automatic tax param in subscription creation

### DIFF
--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -97,7 +97,8 @@ module StripeMock
           customer[:default_source] = new_card[:id]
         end
 
-        allowed_params = %w(customer application_fee_percent coupon items metadata plan quantity source tax_percent trial_end trial_period_days current_period_start created prorate billing_cycle_anchor billing days_until_due idempotency_key enable_incomplete_payments cancel_at_period_end default_tax_rates payment_behavior pending_invoice_item_interval default_payment_method collection_method off_session trial_from_plan expand)
+        allowed_params = %w(customer application_fee_percent coupon items metadata plan quantity source tax_percent trial_end trial_period_days current_period_start created prorate billing_cycle_anchor billing days_until_due idempotency_key enable_incomplete_payments cancel_at_period_end default_tax_rates payment_behavior pending_invoice_item_interval default_payment_method collection_method off_session trial_from_plan expand
+          roration_behavior backdate_start_date transfer_data expand automatic_tax)
         unknown_params = params.keys - allowed_params.map(&:to_sym)
         if unknown_params.length > 0
           raise Stripe::InvalidRequestError.new("Received unknown parameter: #{unknown_params.join}", unknown_params.first.to_s, http_status: 400)


### PR DESCRIPTION
We need this param so this PR https://github.com/circleco/circle/pull/9150 can work.

I tried upgrading stripe-ruby-mock to 3.1.0 (https://github.com/stripe-ruby-mock/stripe-ruby-mock) but ended up with errors in both unit and watir tests.

**Rspec**
<img width="1076" alt="CleanShot 2022-11-29 at 15 52 36@2x" src="https://user-images.githubusercontent.com/1437912/204666133-50149d2c-3384-4252-b51b-338d513c6cf1.png">


**Watir**
<img width="1004" alt="CleanShot 2022-11-29 at 17 52 50@2x" src="https://user-images.githubusercontent.com/1437912/204666060-0a29d7f9-1b5b-456a-8c32-042b1590f12e.png">

<img width="1008" alt="CleanShot 2022-11-29 at 17 52 59@2x" src="https://user-images.githubusercontent.com/1437912/204666043-00748706-345f-4063-aec0-0fa6563acf21.png">


The idea is that we use the current version of the main repo, but due to priority I'll commit exactly what we need in this fork and see if everything goes well in our circle repo.