### PR TITLE
Use File.exist?

### DIFF
--- a/lib/stripe_mock/api/webhooks.rb
+++ b/lib/stripe_mock/api/webhooks.rb
@@ -4,7 +4,7 @@ module StripeMock
 
     fixture_file = File.join(@webhook_fixture_path, "#{type}.json")
 
-    unless File.exists?(fixture_file)
+    unless File.exist?(fixture_file)
       unless Webhooks.event_list.include?(type)
         raise UnsupportedRequestError.new "Unsupported webhook event `#{type}` (Searched in #{@webhook_fixture_path})"
       end


### PR DESCRIPTION
The method File.exists? no longer exists. By changing this method to File.exist? we can remove a monkey patch on Circle app.